### PR TITLE
Refactor to optimize code and improve emulator performance

### DIFF
--- a/src/gpu/gpu.rs
+++ b/src/gpu/gpu.rs
@@ -7,6 +7,8 @@ use crate::{Byte, Word};
 use ::image::{Rgba, RgbaImage};
 use gfx_device_gl::{CommandBuffer, Factory, Resources};
 use piston_window::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 type DisplayPixel = [Byte; 4];
@@ -16,6 +18,8 @@ pub struct GPU {
     sprites_to_be_drawn: Vec<OamEntry>,
 
     memory: Arc<RwLock<Memory>>,
+
+    tile_row_cache: RefCell<HashMap<(Word, u16), (Byte, Byte)>>,
 }
 
 impl GPU {
@@ -32,6 +36,7 @@ impl GPU {
             cycles_acumulated: 0,
             sprites_to_be_drawn: Vec::with_capacity(10),
             memory,
+            tile_row_cache: RefCell::new(HashMap::new()),
         };
     }
 
@@ -76,6 +81,7 @@ impl GPU {
                             // Enter Searching OAM-RAM mode
                             memory.set_stat_mode(STATMode::SearchOamRam);
                             memory.ly_reset();
+                            self.tile_row_cache.borrow_mut().clear();
                         }
                     }
                 }
@@ -87,32 +93,26 @@ impl GPU {
                     // Enter transferring data to LCD Driver mode
                     self.cycles_acumulated = 0;
 
-                    {
-                        let mut memory = self.memory.write().unwrap();
-                        memory.set_stat_mode(STATMode::LCDTransfer);
-                    }
+                    let mut memory = self.memory.write().unwrap();
+                    memory.set_stat_mode(STATMode::LCDTransfer);
 
                     self.sprites_to_be_drawn.clear();
 
-                    {
-                        let mut memory = self.memory.write().unwrap();
+                    let lcdc = &memory.lcdc;
 
-                        let lcdc = &memory.lcdc;
+                    if !lcdc.obj_sprite_display() {
+                        return;
+                    }
 
-                        if !lcdc.obj_sprite_display() {
-                            return;
-                        }
+                    let ly: u8 = memory.ly.clone().into();
+                    let sprite_size = if lcdc.obj_sprite_size() { 16 } else { 8 };
 
-                        let ly: u8 = memory.ly.clone().into();
-                        let sprite_size = if lcdc.obj_sprite_size() { 16 } else { 8 };
-
-                        for oam_entry in memory.oam_ram() {
-                            if oam_entry.x() != 0
-                                && ly + 16 >= oam_entry.y()
-                                && ly + 16 < oam_entry.y() + sprite_size
-                            {
-                                self.sprites_to_be_drawn.push(oam_entry);
-                            }
+                    for oam_entry in memory.oam_ram() {
+                        if oam_entry.x() != 0
+                            && ly + 16 >= oam_entry.y()
+                            && ly + 16 < oam_entry.y() + sprite_size
+                        {
+                            self.sprites_to_be_drawn.push(oam_entry);
                         }
                     }
                 }
@@ -160,6 +160,15 @@ impl GPU {
                     let mut previous_bg_tile_map_location = 0u16;
                     let mut tile_bytes = (0, 0);
 
+                    let sprite_palette0 = memory.read_byte(0xFF48);
+                    let sprite_palette1 = memory.read_byte(0xFF49);
+
+                    let sprite_size = if memory.lcdc.obj_sprite_size() {
+                        16i16
+                    } else {
+                        8i16
+                    };
+
                     for screen_x in 0..(GPU::PIXEL_WIDTH as u16) {
                         let mut pixel_to_write: Option<DisplayPixel> = None;
                         let screen_x_with_offset = scx as u16 + screen_x;
@@ -167,7 +176,14 @@ impl GPU {
 
                         // Sprites with high priority
                         if lcdc.obj_sprite_display() {
-                            pixel_to_write = self.draw_sprites(true, screen_x, screen_y);
+                            pixel_to_write = self.draw_sprites(
+                                true,
+                                screen_x,
+                                screen_y,
+                                sprite_palette0,
+                                sprite_palette1,
+                                sprite_size,
+                            );
                         }
 
                         if lcdc.bg_display() {
@@ -213,7 +229,14 @@ impl GPU {
 
                         // Sprites with high priority
                         if lcdc.obj_sprite_display() {
-                            let tmp = self.draw_sprites(false, screen_x, screen_y);
+                            let tmp = self.draw_sprites(
+                                false,
+                                screen_x,
+                                screen_y,
+                                sprite_palette0,
+                                sprite_palette1,
+                                sprite_size,
+                            );
 
                             if tmp.is_some() {
                                 pixel_to_write = tmp;
@@ -243,25 +266,43 @@ impl GPU {
     }
 
     fn read_tile_row(&self, tile_address: Word, row: u16) -> (Byte, Byte) {
+        let key = (tile_address, row);
+
+        let mut cache = self.tile_row_cache.borrow_mut();
+
+        if cache.contains_key(&key) {
+            return *cache.get(&key).unwrap();
+        }
+
         let memory = self.memory.read().unwrap();
 
         let word = memory.read_word(tile_address + row * 2);
         let bytes = word_to_two_bytes(word);
 
-        (bytes.1, bytes.0)
+        let to_return = (bytes.1, bytes.0);
+
+        cache.insert((tile_address, row), to_return);
+
+        to_return
     }
 
-    fn draw_sprites(&self, priority: bool, screen_x: u16, screen_y: u16) -> Option<DisplayPixel> {
+    fn draw_sprites(
+        &self,
+        priority: bool,
+        screen_x: u16,
+        screen_y: u16,
+        palette0: Byte,
+        palette1: Byte,
+        sprite_size: i16,
+    ) -> Option<DisplayPixel> {
         const SPRITE_TILES_ADDR_START: u16 = 0x8000;
+
+        if self.sprites_to_be_drawn.is_empty() {
+            return None;
+        }
 
         let mut pixel_to_write = None;
         let mut last_drawn: Option<&OamEntry> = None;
-        let sprite_size;
-
-        {
-            let memory = self.memory.read().unwrap();
-            sprite_size = if memory.lcdc.obj_sprite_size() { 16 } else { 8 };
-        }
 
         for sprite in &self.sprites_to_be_drawn {
             if priority != sprite.priority() {
@@ -282,7 +323,7 @@ impl GPU {
             let current_pixel_y: i16 =
                 screen_y as i16 + (GPU::PIXELS_PER_TILE * 2) as i16 - sprite.y() as i16;
 
-            if current_pixel_y < 0 || current_pixel_y >= sprite_size as i16 {
+            if current_pixel_y < 0 || current_pixel_y >= sprite_size {
                 continue;
             }
 
@@ -291,37 +332,32 @@ impl GPU {
             let sprite_addr =
                 SPRITE_TILES_ADDR_START + sprite.tile_number() as u16 * GPU::TILE_SIZE_BYTES as u16;
 
+            let row = if sprite.flip_y() {
+                7 - current_pixel_y
+            } else {
+                current_pixel_y
+            } as Word;
+
+            let tile_row = self.read_tile_row(sprite_addr, row);
+
             let pixel = self.read_pixel_from_tile(
                 if sprite.flip_x() {
                     7 - current_pixel_x
                 } else {
                     current_pixel_x
                 } as Word,
-                self.read_tile_row(
-                    sprite_addr,
-                    if sprite.flip_y() {
-                        7 - current_pixel_y
-                    } else {
-                        current_pixel_y
-                    } as Word,
-                ),
+                tile_row,
             );
 
             if pixel == 0 {
                 continue;
             }
 
-            let palette;
-
-            {
-                let memory = self.memory.read().unwrap();
-
-                palette = memory.read_byte(if sprite.palette() == 0 {
-                    0xFF48
-                } else {
-                    0xFF49
-                });
-            }
+            let palette = if sprite.palette() == 0 {
+                palette0
+            } else {
+                palette1
+            };
 
             let pixel_color = match pixel {
                 0b11 => palette >> 6,

--- a/src/gpu/gpu.rs
+++ b/src/gpu/gpu.rs
@@ -270,8 +270,9 @@ impl GPU {
 
         let mut cache = self.tile_row_cache.borrow_mut();
 
-        if cache.contains_key(&key) {
-            return *cache.get(&key).unwrap();
+        match cache.get(&key) {
+            Some(result) => return *result,
+            _ => {}
         }
 
         let memory = self.memory.borrow();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ use gpu::gpu::GPU;
 use image::ImageBuffer;
 use memory::memory::Memory;
 use piston_window::*;
-use std::sync::{Arc, RwLock};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 const APP_NAME: &str = "RustieGB";
 
@@ -45,7 +46,7 @@ fn main() {
     let bootstrap = matches.is_present("bootstrap");
 
     // --- Setting up GB components
-    let memory = Arc::new(RwLock::new(Memory::new(
+    let memory = Rc::new(RefCell::new(Memory::new(
         matches.value_of("ROMFILE").unwrap(),
         bootstrap,
     )));
@@ -75,7 +76,7 @@ fn main() {
 
     while let Some(event) = window.next() {
         if let Some(Button::Keyboard(key)) = event.press_args() {
-            let mut memory = memory.write().unwrap();
+            let mut memory = memory.borrow_mut();
 
             match key {
                 Key::X => {
@@ -116,7 +117,7 @@ fn main() {
         }
 
         if let Some(Button::Keyboard(key)) = event.release_args() {
-            let mut memory = memory.write().unwrap();
+            let mut memory = memory.borrow_mut();
 
             match key {
                 Key::X => memory.joypad().a = false,
@@ -158,7 +159,7 @@ fn main() {
                     let check_joystick;
 
                     {
-                        let mut memory = memory.write().unwrap();
+                        let mut memory = memory.borrow_mut();
 
                         check_vblank = memory.interrupt_enable().is_vblank()
                             && memory.interrupt_flag().is_vblank();


### PR DESCRIPTION
It has been focused in the GPU code, trying to reduce reads from memory and caching values. Despite this, also Arcs and RwLocks had been replaced by Rcs and RefCells, as they were not necessary.